### PR TITLE
Updated prometheus src url

### DIFF
--- a/roles/monitoring_server/tasks/main.yml
+++ b/roles/monitoring_server/tasks/main.yml
@@ -26,7 +26,7 @@
 
 - name: Install prometheus
   unarchive:
-    src: 'https://github.com/prometheus/prometheus/releases/latest/download/prometheus-{{ version }}.linux-armv7.tar.gz'
+    src: 'https://github.com/prometheus/prometheus/releases/download/v{{ version }}/prometheus-{{ version }}.linux-armv7.tar.gz'
     dest: /tmp/
     remote_src: yes
 


### PR DESCRIPTION
Since version `2.17.2` no longer has the `latest` tag on Github, the url returns a 404.

```
TASK [monitoring_server : Install prometheus] ********************************************************************
fatal: [pistack0]: FAILED! => {"changed": false, "msg": "Failure downloading https://github.com/prometheus/prometheus/releases/latest/download/prometheus-2.17.2.linux-armv7.tar.gz, HTTP Error 404: Not Found"}
```

I got the URL structure from here https://github.com/prometheus/prometheus/releases/tag/v2.17.2

Had to make this change to get the playbook to execute all the way through.

ps. thanks for this repo, great work!